### PR TITLE
Adding query_orders, ledgers and query_ledgers

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,18 @@ client.trade_volume
 client.trade_volume(pair: 'XBTEUR, etcusd, xbteth')
 ```
 
+### Retrieve ledgers
+
+```ruby
+ledgers = client.ledgers(asset: "AAVE")
+```
+
+### Query ledgers
+
+```ruby
+ledgers = client.query_ledgers(id: "LX4A-QQQ")
+```
+
 ### Get deposit methods
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -183,6 +183,18 @@ open_orders.select { |_, v| v.dig('descr', 'pair') == pair }.first(10).each do |
 end
 ```
 
+### Query orders
+
+```ruby
+# Query all orders based on a transaction id
+queried_orders = client.query_orders(txid: txid)
+```
+
+```ruby
+# Query all orders based on a userref
+queried_orders = client.query_orders(userref: userref)
+```
+
 ### Place a limit buy order
 
 ```ruby

--- a/lib/kraken_ruby_client/client.rb
+++ b/lib/kraken_ruby_client/client.rb
@@ -399,6 +399,50 @@ module Kraken
       post_private 'QueryOrders', opts
     end
 
+    # Get Ledgers Info (POST)
+    # URL: https://api.kraken.com/0/private/Ledgers
+    # Input:
+    #   +asset+     comma delimited list of asset names to get info on (optional.)
+    #   +aclass+    asset class (optional): currency (default) or asset
+    #   +type+      type of ledger to retrieve (optional): all(default), deposit, withdrawal, trade, margin
+    #   +start+     start UNIX timestamp or order txid (optional. exclusive)
+    #   +end+       end UNIX timestamp or order txid (optional. inclusive)
+    #   +ofs+       result offset
+    # Note: Times given by order txids are more accurate than UNIX timestamps.
+    #       If an order txid is given, the order's open time is used.
+    #
+    # Examples:
+    #
+    # require 'kraken_ruby_client'
+    # client = Kraken::Client.new(api_key: YOUR_KEY, api_secret: YOUR_SECRET)
+    #
+    # Return ledgers based on a particular asset
+    #
+    #   ledgers = client.ledgers(asset: "AAVE")
+    #
+    def ledgers(opts = {})
+      post_private 'Ledgers', opts
+    end
+
+    # Query Ledgers (POST)
+    # URL: https://api.kraken.com/0/private/QueryLedgers
+    # Input:
+    #   +id+        comma delimited list of ledger IDs to query info about (20 maximum)
+    #   +trades+    predicate to include trades (optional, default `false`)
+    #
+    # Examples:
+    #
+    # require 'kraken_ruby_client'
+    # client = Kraken::Client.new(api_key: YOUR_KEY, api_secret: YOUR_SECRET)
+    #
+    # Return ledger info on a specific ledger
+    #
+    #   ledgers = client.ledgers(id: "LX4A-QQQ")
+    #
+    def query_ledgers(opts = {})
+      post_private 'QueryLedgers', opts
+    end
+
     # Get deposit methods (POST)
     #
     # Examples:

--- a/lib/kraken_ruby_client/client.rb
+++ b/lib/kraken_ruby_client/client.rb
@@ -379,6 +379,26 @@ module Kraken
       post_private 'ClosedOrders', opts
     end
 
+    # Query Orders Info (POST)
+    # URL: https://api.kraken.com/0/private/QueryOrders
+    # Input:
+    #   +trades+    predicate to include trades (optional, default `false`)
+    #   +userref+   restrict results to given user reference id (optional)
+    #   +txid+      Comma delimited list of transaction IDs to query info about (20 maximum)
+    #
+    # Examples:
+    #
+    # require 'kraken_ruby_client'
+    # client = Kraken::Client.new(api_key: YOUR_KEY, api_secret: YOUR_SECRET)
+    #
+    # Return orders based on a transaction id
+    #
+    #   queried_orders = client.query_orders(txid: txid)
+    #
+    def query_orders(opts = {})
+      post_private 'QueryOrders', opts
+    end
+
     # Get deposit methods (POST)
     #
     # Examples:


### PR DESCRIPTION
I wanted to bring over some methods that I've added, which are part of the main API.

### Query orders

```ruby
# Query all orders based on a transaction id
queried_orders = client.query_orders(txid: txid)
```

```ruby
# Query all orders based on a userref
queried_orders = client.query_orders(userref: userref)
```

### Retrieve ledgers
```ruby
ledgers = client.ledgers(asset: "AAVE")
```
### Query ledgers
```ruby
ledgers = client.query_ledgers(id: "LX4A-QQQ")
```